### PR TITLE
changed msg equality to 2 minute buffer to fix an assert

### DIFF
--- a/python_scraper/whatsapp_scraper.py
+++ b/python_scraper/whatsapp_scraper.py
@@ -95,7 +95,7 @@ class Msg():
                                         self.content[:50].replace('\n', '\\n'))
 
     def __eq__(self, other):
-        return (self.dt == other.dt
+        return (abs((self.dt - other.dt).total_seconds()) <= 120
                 and self.sender_id == other.sender_id
                 and self.group_id == other.group_id
                 and self.content == other.content)


### PR DESCRIPTION
On merge, there is an assertion to ensure data integrity by comparing two lists of messages - one on the server and one locally. The assert was failing for 2 messages in a comparison of about 50 because the time on the two messages was one minute apart. This PR creates a two minutes of wiggle-room when testing message equality. Group, sender, and content have to all still equal each other.